### PR TITLE
Add pagination option

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,5 +1,5 @@
 go:
-    cgo: true
+    cgo: false
 verbose: true
 repository:
     path: github.com/masaruhoshi/uptimerobot-prometheus-exporter    

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ tarballs: format test promu
 	
 docker: deps format 
 	@echo ">> building binary"
-	GOOS=linux GOARCH=amd64 $(GO) build -o uptimerobot-exporter
+	GOOS=linux GOARCH=amd64 $(PROMU) build --prefix $(PREFIX)
 	@echo ">> building docker image"
 	@docker build -t "$(DOCKER_IMAGE_NAME)" .
 

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -115,31 +115,11 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	monitors := client.Monitors()
-	var request = api.GetMonitorsRequest{
-		ResponseTimes:      1,
-		ResponseTimesLimit: 1,
-	}
-
-	response, err := monitors.Get(request)
-	if err != nil {
-		log.Errorln("Error getting monitors", err)
-		e.errorDesc.Set(1)
-		return
-	}
-	log.Infof("Response from UptimeRobot API", response)
-
-	if response == nil {
-		log.Errorln("No monitor response: %v", response)
-		e.errorDesc.Set(1)
-		return
-	}
-
 	e.up.Set(1)
 	ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, time.Since(scrapeTime).Seconds(), "connection")
 
 	scrapeTime = time.Now()
-	if err = ScrapeUptimeRobot(response.Monitors, ch); err != nil {
+	if err = ScrapeUptimeRobot(client, ch); err != nil {
 		log.Errorln("Error scraping for collect.uptimerobot:", err)
 		e.scrapeErrors.WithLabelValues("collect.uptimerobot").Inc()
 		e.errorDesc.Set(1)

--- a/collector/uptimerobot.go
+++ b/collector/uptimerobot.go
@@ -45,41 +45,77 @@ var (
 )
 
 // ScrapeUptimeRobot : scrapes from UptimeRobot API.
-func ScrapeUptimeRobot(monitors []api.XMLMonitor, ch chan<- prometheus.Metric) error {
-	log.Infof("ScrapeUptimeRobot found %d monitors", len(monitors))
-	for _, monitor := range monitors {
-		up := 1.0
-		status, _ := strconv.ParseFloat(monitor.Status, 64)
-		responseTime := float64(monitor.ResponseTimes[0].Value)
-		if status != statusUp {
-			up = 0
-		}
+func ScrapeUptimeRobot(client *api.Client, ch chan<- prometheus.Metric) error {
+	offset, totalScraped, totalMonitors := 0, 0, 0
 
-		ch <- prometheus.MustNewConstMetric(
-			MonitorUpDesc,
-			prometheus.GaugeValue,
-			up,
-			monitor.FriendlyName,
-			monitor.Type,
-			monitor.URL,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			MonitorStatusDesc,
-			prometheus.GaugeValue,
-			status,
-			monitor.FriendlyName,
-			monitor.Type,
-			monitor.URL,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			MonitorResponseTimeDesc,
-			prometheus.GaugeValue,
-			responseTime,
-			monitor.FriendlyName,
-			monitor.Type,
-			monitor.URL,
-		)
+	for {
+		monitors, err := getMonitors(client, offset)
+		if err != nil {
+			return err
+		}
+		for _, monitor := range monitors {
+			log.Infof("ScrapeUptimeRobot found %d monitors", monitor.Pagination.Total)
+			totalMonitors = monitor.Pagination.Total
+			up := 1.0
+			status, _ := strconv.ParseFloat(monitor.Status, 64)
+			responseTime := float64(monitor.ResponseTimes[0].Value)
+			if status != statusUp {
+				up = 0
+			}
+
+			ch <- prometheus.MustNewConstMetric(
+				MonitorUpDesc,
+				prometheus.GaugeValue,
+				up,
+				monitor.FriendlyName,
+				monitor.Type,
+				monitor.URL,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				MonitorStatusDesc,
+				prometheus.GaugeValue,
+				status,
+				monitor.FriendlyName,
+				monitor.Type,
+				monitor.URL,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				MonitorResponseTimeDesc,
+				prometheus.GaugeValue,
+				responseTime,
+				monitor.FriendlyName,
+				monitor.Type,
+				monitor.URL,
+			)
+		}
+		totalScraped += len(monitors)
+		if totalScraped < totalMonitors {
+			offset++
+		} else {
+			return nil
+		}
+	}
+}
+
+func getMonitors(client *api.Client, offset int) ([]api.XMLMonitor, error) {
+	monitorsRequest := client.Monitors()
+	var request = api.GetMonitorsRequest{
+		ResponseTimes:      1,
+		ResponseTimesLimit: 1,
+		Offset:             offset,
 	}
 
-	return nil
+	response, err := monitorsRequest.Get(request)
+	if err != nil {
+		log.Errorln("Error getting monitorsRequest", err)
+		return nil, err
+	}
+	log.Infof("Response from UptimeRobot API", response)
+
+	if response == nil {
+		log.Errorln("No monitor response: %v", response)
+		return nil, err
+	}
+
+	return response.Monitors, nil
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/masaruhoshi/uptimerobot-prometheus-exporter
 import:
 - package: github.com/masaruhoshi/uptimerobot-go.v2
-  version: 54ce6812c3c27385970d5649e113738d638252e3
+  version: ed9418476844df512cf6ba9306bf7b9f6a8b5060
 - package: github.com/golang/glog
 - package: github.com/prometheus/client_golang
   version: v0.8.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/masaruhoshi/uptimerobot-prometheus-exporter
 import:
 - package: github.com/masaruhoshi/uptimerobot-go.v2
-  version: ed9418476844df512cf6ba9306bf7b9f6a8b5060
+  version: 91f84c8702f522ff79b737ce69a9518df4365aa1
 - package: github.com/golang/glog
 - package: github.com/prometheus/client_golang
   version: v0.8.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/masaruhoshi/uptimerobot-prometheus-exporter
 import:
 - package: github.com/masaruhoshi/uptimerobot-go.v2
-  version: 402c8be8f98af30114efe21f749b67e1b53a6222
+  version: 54ce6812c3c27385970d5649e113738d638252e3
 - package: github.com/golang/glog
 - package: github.com/prometheus/client_golang
   version: v0.8.0


### PR DESCRIPTION
# Description
UptimeRobot uses pagination when returning monitors. UptimeRobot limits the number of monitors returned by the `/getMonitors` endpoint to 50 records. More than that it's necessary to specify an offset for the pagination.

This PR introduces the ability to scrape more than the limit set by the API using the pagination offset properly.