### PR TITLE
Handle newly added monitor

### DIFF
--- a/collector/uptimerobot.go
+++ b/collector/uptimerobot.go
@@ -57,6 +57,8 @@ func ScrapeUptimeRobot(client *api.Client, ch chan<- prometheus.Metric) error {
 		totalMonitors = xmlMonitors.Pagination.Total
 		for _, monitor := range xmlMonitors.Monitors {
 			up := 1.0
+			status := 0.0
+			responseTime := 0.0
 
 			if scappedMonitors[monitor.ID] {
 				log.Warnf("Trying to scrape a duplicate monitor for %s", monitor.FriendlyName)
@@ -64,10 +66,10 @@ func ScrapeUptimeRobot(client *api.Client, ch chan<- prometheus.Metric) error {
 			}
 			if monitor.ResponseTimes == nil {
 				log.Warnf("No response times collected for %s", monitor.FriendlyName)
-				continue
+			} else {
+				status, _ = strconv.ParseFloat(monitor.Status, 64)
+				responseTime = float64(monitor.ResponseTimes[0].Value)
 			}
-			status, _ := strconv.ParseFloat(monitor.Status, 64)
-			responseTime := float64(monitor.ResponseTimes[0].Value)
 			if status != statusUp {
 				up = 0
 			}


### PR DESCRIPTION
When a listed monitor is returned without response time data, it breaks scrapping the data for other monitors. 

This PR defaults `status` and `responseTime` to OFFLINE and 0, respectively to avoid the scrapping from further fails. 